### PR TITLE
fix - removed unused props & resolved project pagination issue on homefeed

### DIFF
--- a/src/app/features/projects/projectsSlice.js
+++ b/src/app/features/projects/projectsSlice.js
@@ -52,7 +52,6 @@ const projectSlice = createSlice({
             state.loading = false
             state.projects = action.payload.projects
             state.hasMore = action.payload.hasNextPage
-            state.page = 2 // First page is fetched, so setting to 2 for the next fetch
         },
 
         /**
@@ -75,6 +74,7 @@ const projectSlice = createSlice({
         fetchMoreProjectsStart: (state) => {
             state.fetchingMore = true
             state.error = null
+            state.page = state.page + 1
         },
 
         /**
@@ -87,10 +87,9 @@ const projectSlice = createSlice({
          * @param {boolean} action.payload.hasNextPage - Indicates if there are more projects to fetch.
          */
         fetchMoreProjectsSuccess: (state, action) => {
-            state.fetchingMore = false;
-            state.projects = [...state.projects, ...action.payload.projects];
-            state.hasMore = action.payload.hasNextPage;
-            state.page = state.page + 1;
+            state.fetchingMore = false
+            state.projects = [...state.projects, ...action.payload.projects]
+            state.hasMore = action.payload.hasNextPage
         },
 
         /**
@@ -101,8 +100,8 @@ const projectSlice = createSlice({
          * @param {string} action.payload - Error message.
          */
         fetchMoreProjectsFailure: (state, action) => {
-            state.fetchingMore = false;
-            state.error = action.payload;
+            state.fetchingMore = false
+            state.error = action.payload
         }
     },
 })

--- a/src/components/ProjectCardComponent/ProjectCardSupportingComponents/ProjectCardButtons.jsx
+++ b/src/components/ProjectCardComponent/ProjectCardSupportingComponents/ProjectCardButtons.jsx
@@ -17,9 +17,6 @@ function ProjectCardButtons({ project, handleShareClick }) {
 }
 
 ProjectCardButtons.propTypes = {
-    isUpvoted: PropTypes.bool.isRequired,
-    upvoteCount: PropTypes.number.isRequired,
-    handleUpvoteClick: PropTypes.func.isRequired,
     handleShareClick: PropTypes.func.isRequired,
 }
 


### PR DESCRIPTION
### PR Comment:
This PR resolves two issues in the project module:

- PropTypes Warnings in ProjectCardButtons
- Home Page Showing No Projects on Return Due to Premature Page State Change

### Bug 1: PropTypes Warning
**Steps to Reproduce:**

1. Open a project page containing the ProjectCardButtons component.
2. Observe the console for warnings about missing props like isUpvoted, upvoteCount, and handleUpvoteClick.

**Expected:**
No warnings should appear if those props are unused.
**Actual:**
Console shows PropTypes warnings for unused/missing props.

### Bug 2: Projects Not Showing on Home Page Return
**Steps to Reproduce:**

1. Open the app and land on the home feed.
2. Navigate into a project.
3. Return back to the home page.

**Expected:**
The home feed should display the first page of projects.
**Actual:**
It shows no projects — this is because:

- fetchInitialProjectsSuccess was prematurely setting page = 2 even though only the first page was fetched.
- So when returning to home, it tries to fetch from page 2, which may not exist — resulting in an empty project list.

### Fix:
**1. PropTypes Fix**
Removed unused props (isUpvoted, upvoteCount, handleUpvoteClick) from ProjectCardButtons.

**2. Redux Pagination Fix**

- Removed state.page = 2 from fetchInitialProjectsSuccess — now the initial page remains 1.
- Moved the page increment logic to fetchMoreProjectsStart, so the page state only increases during infinite scroll, not on every initial fetch.

### Browsers/OS Tested:
Brave, Chrome, Arc, Safari / macOS

### Before Fix:

- Console warnings on project pages.
- Home shows no projects after navigating back.

<img width="1912" alt="Screenshot 2025-04-08 at 7 26 48 PM" src="https://github.com/user-attachments/assets/e663d9aa-b15b-4a58-85a1-693c5f662b49" />

<img width="1800" alt="Screenshot 2025-04-08 at 8 10 25 PM" src="https://github.com/user-attachments/assets/65d4c862-5c21-4a14-9592-2af872a43e42" />



### After Fix:

- No PropTypes warnings.
- Home consistently displays projects, even after navigation.

<img width="1912" alt="Screenshot 2025-04-08 at 8 09 00 PM" src="https://github.com/user-attachments/assets/b7b1d2a5-a31b-46c9-ad3a-f36b7bb5866a" />

<img width="1912" alt="Screenshot 2025-04-08 at 8 09 05 PM" src="https://github.com/user-attachments/assets/3f29a092-bcd9-4374-a913-b50e33a3b6a2" />


